### PR TITLE
fix build failures with gcc 13

### DIFF
--- a/src/kmers.h
+++ b/src/kmers.h
@@ -17,6 +17,7 @@
 #define KMERS_H
 
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <unordered_set>


### PR DESCRIPTION
Initially seen in [Debian Bug#1037655], Filtlong fails to build with gcc 13.  The relevant part of the build log looks like:

	In file included from src/read.h:25,
	                 from src/read.cpp:22:
	src/kmers.h:37:26: error: ‘uint32_t’ has not been declared
	   37 |     bool is_kmer_present(uint32_t kmer);
	      |                          ^~~~~~~~
	src/kmers.h:39:5: error: ‘uint32_t’ does not name a type
	   39 |     uint32_t starting_kmer_to_bits_forward(char * sequence);
	      |     ^~~~~~~~
	src/kmers.h:25:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?

Adding cstdint to kmers.h per compiler hint allows the build to go through.

[Debian Bug#1037655]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1037655