### PR TITLE
fix uint32_t has not been declared error

### DIFF
--- a/src/kmers.h
+++ b/src/kmers.h
@@ -17,6 +17,7 @@
 #define KMERS_H
 
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <unordered_set>


### PR DESCRIPTION
On Ubuntu 24.04.2 LTS and g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0 compilation fails with this error:

```
g++ -std=c++11 -O3 -Wall -Wextra -pedantic -mtune=native -c -o src/main.o src/main.cpp
g++ -std=c++11 -O3 -Wall -Wextra -pedantic -mtune=native -c -o src/kmers.o src/kmers.cpp
g++ -std=c++11 -O3 -Wall -Wextra -pedantic -mtune=native -c -o src/arguments.o src/arguments.cpp
g++ -std=c++11 -O3 -Wall -Wextra -pedantic -mtune=native -c -o src/read.o src/read.cpp
g++ -std=c++11 -O3 -Wall -Wextra -pedantic -mtune=native -c -o src/misc.o src/misc.cpp
In file included from src/kmers.cpp:17:
src/kmers.h:37:26: error: ‘uint32_t’ has not been declared
   37 |     bool is_kmer_present(uint32_t kmer);
      |                          ^~~~~~~~
src/kmers.h:39:5: error: ‘uint32_t’ does not name a type
   39 |     uint32_t starting_kmer_to_bits_forward(char * sequence);
      |     ^~~~~~~~
src/kmers.h:25:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   24 | #include "bloom_filter.h"
  +++ |+#include <cstdint>
   25 | 
src/kmers.h:40:5: error: ‘uint32_t’ does not name a type
   40 |     uint32_t starting_kmer_to_bits_reverse(char * sequence);
      |     ^~~~~~~~
src/kmers.h:40:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:42:5: error: ‘uint32_t’ does not name a type
   42 |     uint32_t base_to_bits_forward(char base);
      |     ^~~~~~~~
src/kmers.h:42:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:43:5: error: ‘uint32_t’ does not name a type
   43 |     uint32_t base_to_bits_reverse(char base);
      |     ^~~~~~~~
src/kmers.h:43:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:46:24: error: ‘uint32_t’ was not declared in this scope
   46 |     std::unordered_set<uint32_t> m_kmers;
      |                        ^~~~~~~~
src/kmers.h:46:24: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:46:32: error: template argument 1 is invalid
   46 |     std::unordered_set<uint32_t> m_kmers;
      |                                ^
src/kmers.h:46:32: error: template argument 2 is invalid
src/kmers.h:46:32: error: template argument 3 is invalid
src/kmers.h:46:32: error: template argument 4 is invalid
src/kmers.h:47:24: error: ‘uint32_t’ was not declared in this scope
   47 |     std::unordered_map<uint32_t, int> m_kmer_counts;
      |                        ^~~~~~~~
src/kmers.h:47:24: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:47:37: error: template argument 1 is invalid
   47 |     std::unordered_map<uint32_t, int> m_kmer_counts;
      |                                     ^
src/kmers.h:47:37: error: template argument 3 is invalid
src/kmers.h:47:37: error: template argument 4 is invalid
src/kmers.h:47:37: error: template argument 5 is invalid
src/kmers.h:52:36: error: ‘uint32_t’ has not been declared
   52 |     void add_kmer_require_one_copy(uint32_t kmer);
      |                                    ^~~~~~~~
src/kmers.h:53:43: error: ‘uint32_t’ has not been declared
   53 |     void add_kmer_require_multiple_copies(uint32_t kmer);
      |                                           ^~~~~~~~
src/kmers.h: In member function ‘bool Kmers::empty()’:
src/kmers.h:33:34: error: request for member ‘size’ in ‘((Kmers*)this)->Kmers::m_kmers’, which is of non-class type ‘int’
   33 |     bool empty() {return m_kmers.size() == 0;}
      |                                  ^~~~
In file included from src/read.h:25,
                 from src/read.cpp:22:
src/kmers.h:37:26: error: ‘uint32_t’ has not been declared
   37 |     bool is_kmer_present(uint32_t kmer);
      |                          ^~~~~~~~
src/kmers.h:39:5: error: ‘uint32_t’ does not name a type
   39 |     uint32_t starting_kmer_to_bits_forward(char * sequence);
      |     ^~~~~~~~
src/kmers.h:25:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   24 | #include "bloom_filter.h"
  +++ |+#include <cstdint>
   25 | 
src/kmers.h:40:5: error: ‘uint32_t’ does not name a type
   40 |     uint32_t starting_kmer_to_bits_reverse(char * sequence);
      |     ^~~~~~~~
src/kmers.h:40:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:42:5: error: ‘uint32_t’ does not name a type
   42 |     uint32_t base_to_bits_forward(char base);
      |     ^~~~~~~~
src/kmers.h:42:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:43:5: error: ‘uint32_t’ does not name a type
   43 |     uint32_t base_to_bits_reverse(char base);
      |     ^~~~~~~~
src/kmers.h:43:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:46:24: error: ‘uint32_t’ was not declared in this scope
   46 |     std::unordered_set<uint32_t> m_kmers;
      |                        ^~~~~~~~
src/kmers.h:46:24: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:46:32: error: template argument 1 is invalid
   46 |     std::unordered_set<uint32_t> m_kmers;
      |                                ^
src/kmers.h:46:32: error: template argument 2 is invalid
src/kmers.h:46:32: error: template argument 3 is invalid
src/kmers.h:46:32: error: template argument 4 is invalid
src/kmers.h:47:24: error: ‘uint32_t’ was not declared in this scope
   47 |     std::unordered_map<uint32_t, int> m_kmer_counts;
      |                        ^~~~~~~~
src/kmers.h:47:24: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
src/kmers.h:47:37: error: template argument 1 is invalid
   47 |     std::unordered_map<uint32_t, int> m_kmer_counts;
      |                                     ^
src/kmers.h:47:37: error: template argument 3 is invalid
src/kmers.h:47:37: error: template argument 4 is invalid
src/kmers.h:47:37: error: template argument 5 is invalid
src/kmers.h:52:36: error: ‘uint32_t’ has not been declared
   52 |     void add_kmer_require_one_copy(uint32_t kmer);
      |                                    ^~~~~~~~
src/kmers.h:53:43: error: ‘uint32_t’ has not been declared
   53 |     void add_kmer_require_multiple_copies(uint32_t kmer);
      |                                           ^~~~~~~~
src/kmers.h: In member function ‘bool Kmers::empty()’:
src/kmers.h:33:34: error: request for member ‘size’ in ‘((Kmers*)this)->Kmers::m_kmers’, which is of non-class type ‘int’
   33 |     bool empty() {return m_kmers.size() == 0;}
      |                                  ^~~~
src/read.cpp: In constructor ‘Read::Read(std::string, char*, char*, int, Kmers*, Arguments*)’:
src/read.cpp:46:13: error: ‘uint32_t’ was not declared in this scope
   46 |             uint32_t kmer = kmers->starting_kmer_to_bits_forward(seq);
      |             ^~~~~~~~
src/read.cpp:24:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   23 | #include "misc.h"
  +++ |+#include <cstdint>
   24 | 
src/read.cpp:49:21: error: ‘kmer’ was not declared in this scope; did you mean ‘kmers’?
   49 |                     kmer <<= 2;
      |                     ^~~~
      |                     kmers
src/read.cpp:50:36: error: ‘class Kmers’ has no member named ‘base_to_bits_forward’
   50 |                     kmer |= kmers->base_to_bits_forward(seq[i]);
      |                                    ^~~~~~~~~~~~~~~~~~~~
src/read.cpp:52:44: error: ‘kmer’ was not declared in this scope; did you mean ‘kmers’?
   52 |                 if (kmers->is_kmer_present(kmer)) {
      |                                            ^~~~
      |                                            kmers
src/kmers.cpp: In member function ‘void Kmers::add_read_fastqs(std::vector<std::__cxx11::basic_string<char> >)’:
src/kmers.cpp:57:40: error: request for member ‘size’ in ‘((Kmers*)this)->Kmers::m_kmers’, which is of non-class type ‘int’
   57 |               << int_to_string(m_kmers.size()) << " 16-mers\n\n";
      |                                        ^~~~
src/kmers.cpp: In member function ‘void Kmers::add_assembly_fasta(std::string)’:
src/kmers.cpp:71:40: error: request for member ‘size’ in ‘((Kmers*)this)->Kmers::m_kmers’, which is of non-class type ‘int’
   71 |               << int_to_string(m_kmers.size()) << " 16-mers\n\n";
      |                                        ^~~~
src/kmers.cpp: In member function ‘int Kmers::add_reference(std::string, bool)’:
src/kmers.cpp:83:20: error: cannot convert ‘void (Kmers::*)(int)’ to ‘void (Kmers::*)(uint32_t)’ {aka ‘void (Kmers::*)(unsigned int)’} in assignment
   83 |         add_kmer = &Kmers::add_kmer_require_multiple_copies;
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/kmers.cpp:85:20: error: cannot convert ‘void (Kmers::*)(int)’ to ‘void (Kmers::*)(uint32_t)’ {aka ‘void (Kmers::*)(unsigned int)’} in assignment
   85 |         add_kmer = &Kmers::add_kmer_require_one_copy;
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/kmers.cpp:106:28: error: ‘starting_kmer_to_bits_forward’ was not declared in this scope
  106 |             forward_kmer = starting_kmer_to_bits_forward(sequence);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/kmers.cpp:107:28: error: ‘starting_kmer_to_bits_reverse’ was not declared in this scope
  107 |             reverse_kmer = starting_kmer_to_bits_reverse(sequence);
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/kmers.cpp:114:33: error: ‘base_to_bits_forward’ was not declared in this scope
  114 |                 forward_kmer |= base_to_bits_forward(sequence[i]);
      |                                 ^~~~~~~~~~~~~~~~~~~~
src/kmers.cpp:117:33: error: ‘base_to_bits_reverse’ was not declared in this scope
  117 |                 reverse_kmer |= base_to_bits_reverse(sequence[i]);
      |                                 ^~~~~~~~~~~~~~~~~~~~
src/kmers.cpp: At global scope:
src/kmers.cpp:137:6: error: no declaration matches ‘void Kmers::add_kmer_require_one_copy(uint32_t)’
  137 | void Kmers::add_kmer_require_one_copy(uint32_t kmer) {
      |      ^~~~~
src/kmers.h:52:10: note: candidate is: ‘void Kmers::add_kmer_require_one_copy(int)’
   52 |     void add_kmer_require_one_copy(uint32_t kmer);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
src/kmers.h:27:7: note: ‘class Kmers’ defined here
   27 | class Kmers
      |       ^~~~~
src/kmers.cpp:142:6: error: no declaration matches ‘void Kmers::add_kmer_require_multiple_copies(uint32_t)’
  142 | void Kmers::add_kmer_require_multiple_copies(uint32_t kmer) {
      |      ^~~~~
src/kmers.h:53:10: note: candidate is: ‘void Kmers::add_kmer_require_multiple_copies(int)’
   53 |     void add_kmer_require_multiple_copies(uint32_t kmer);
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/kmers.h:27:7: note: ‘class Kmers’ defined here
   27 | class Kmers
      |       ^~~~~
src/kmers.cpp:170:6: error: no declaration matches ‘bool Kmers::is_kmer_present(uint32_t)’
  170 | bool Kmers::is_kmer_present(uint32_t kmer) {
      |      ^~~~~
src/kmers.h:37:10: note: candidate is: ‘bool Kmers::is_kmer_present(int)’
   37 |     bool is_kmer_present(uint32_t kmer);
      |          ^~~~~~~~~~~~~~~
src/kmers.h:27:7: note: ‘class Kmers’ defined here
   27 | class Kmers
      |       ^~~~~
src/kmers.cpp:176:10: error: no declaration matches ‘uint32_t Kmers::base_to_bits_forward(char)’
  176 | uint32_t Kmers::base_to_bits_forward(char base) {
      |          ^~~~~
src/kmers.cpp:176:10: note: no functions named ‘uint32_t Kmers::base_to_bits_forward(char)’
src/kmers.h:27:7: note: ‘class Kmers’ defined here
   27 | class Kmers
      |       ^~~~~
src/kmers.cpp:199:10: error: no declaration matches ‘uint32_t Kmers::base_to_bits_reverse(char)’
  199 | uint32_t Kmers::base_to_bits_reverse(char base) {
      |          ^~~~~
src/kmers.cpp:199:10: note: no functions named ‘uint32_t Kmers::base_to_bits_reverse(char)’
src/kmers.h:27:7: note: ‘class Kmers’ defined here
   27 | class Kmers
      |       ^~~~~
src/kmers.cpp:222:10: error: no declaration matches ‘uint32_t Kmers::starting_kmer_to_bits_forward(char*)’
  222 | uint32_t Kmers::starting_kmer_to_bits_forward(char * sequence) {
      |          ^~~~~
src/kmers.cpp:222:10: note: no functions named ‘uint32_t Kmers::starting_kmer_to_bits_forward(char*)’
src/kmers.h:27:7: note: ‘class Kmers’ defined here
   27 | class Kmers
      |       ^~~~~
src/kmers.cpp:232:10: error: no declaration matches ‘uint32_t Kmers::starting_kmer_to_bits_reverse(char*)’
  232 | uint32_t Kmers::starting_kmer_to_bits_reverse(char * sequence) {
      |          ^~~~~
src/kmers.cpp:232:10: note: no functions named ‘uint32_t Kmers::starting_kmer_to_bits_reverse(char*)’
src/kmers.h:27:7: note: ‘class Kmers’ defined here
   27 | class Kmers
      |       ^~~~~
src/arguments.cpp: In constructor ‘Arguments::Arguments(int, char**)’:
src/arguments.cpp:155:18: warning: catching polymorphic type ‘class args::Help’ by value [-Wcatch-value=]
  155 |     catch (args::Help) {
      |                  ^~~~
src/arguments.cpp:160:29: warning: catching polymorphic type ‘class args::ParseError’ by value [-Wcatch-value=]
  160 |     catch (args::ParseError e) {
      |                             ^
src/arguments.cpp:165:34: warning: catching polymorphic type ‘class args::ValidationError’ by value [-Wcatch-value=]
  165 |     catch (args::ValidationError e) {
      |                                  ^
make: *** [Makefile:49: src/kmers.o] Error 1
make: *** Waiting for unfinished jobs....
make: *** [Makefile:49: src/read.o] Error 1
```
Including  cstdint in kmer.h fixes it. I don't get this error on macOS and clang. Fixes #42.